### PR TITLE
Remove pin for filebrowser_safe from mezzanine to ensure it will work with filebrowser_safe master or the django-2.2 branches. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ try:
         install_requires=[
             "django-contrib-comments",
             "django >= 1.11, < 2.1",
-            "filebrowser_safe >= 0.5.0",
+            "filebrowser_safe",
             "grappelli_safe >= 0.5.0",
             "tzlocal >= 1.0",
             "bleach >= 2.0",


### PR DESCRIPTION
This does not feel great but should allow us to rebuild docker images for local again. Full details are here: https://startupgrind.atlassian.net/browse/SGP-15334 ping me if the notes are unclear. 

Alternatively, we could ping the version to exactly the one listed in the filebrowser_safe branch. But i'm a little worried about that since this issue seems to only show up in local and not prod. 

----- Maybe tl;dr but here is an overview: 


In the platform requirements.txt we list

git+https://github.com/startupgrind/filebrowser-safe.git@2ba7b20bdfa74b8ba543ecc861a52e0942aa84aa
#=filebrowser-safe=0.5.1-sgp11834

2ba7b20bdfa74b8ba543ecc861a52e0942aa84aa seems to be on a non-master branch called 2.2-compat 
here https://github.com/startupgrind/filebrowser-safe/pull/6/commits This version was set in setup.py to 0.5.1-sgp11834 to "Ensures an updated based on a pre-release version." around 6/8/2020. Not sure why we use this branch and not master. 🤷 but I assume it was for trying to do the Django upgrade before the pre-alpha of Mezzanine five rolled out in September 2020. 

As you can see in the Diff for this PR our Mezzanine setup is tagged to >=0.5.0. As a result when I tried building the local docker image it fails. 
docker build . -f Dockerfile-app-base -t us.gcr.io/bevylabs-engineering/platform_base_local:1.2.0

returns an error due to pip conflicts: 

mezzanine 4.3.1.post1 depends on filebrowser_safe>=0.5.0 build failure issue 
The conflict is caused by:
#14 117.7     The user requested filebrowser-safe 0.5.1-sgp11834 (from git+https://github.com/startupgrind/filebrowser-safe.git@2ba7b20bdfa74b8ba543ecc861a52e0942aa84aa)

And that is correct since 0.5.1-sgp11834 is not >=0.5.0. The Master branch is set to 0.5.0 https://github.com/startupgrind/filebrowser-safe/blob/master/setup.py#L25

So removing the pinned version from Mezzanine here will allow us to install filebrowser-safe from the master branch or 2.2-compat branch. 


